### PR TITLE
enabling trimming of x/y axes + tweak to coverage

### DIFF
--- a/examples/run.py
+++ b/examples/run.py
@@ -2,81 +2,93 @@ from scousepy import scouse
 from astropy.io import fits
 import os
 import sys
-
 import pylab as pl
-#pl.ioff()
 pl.ion()
 
 def run_scousepy():
-    # Input values for core SCOUSE stages
+    # Input values for core SCOUSE stages (see help in scouse.py for more info)
+    # Data directory - scouse will dump the output stuff into the same directory
+    # as your fits file by default but you can change this using the keyword
+    # outputdir.
     datadirectory    =  './'
-    # The data cube to be analysed
+    # The data cube to be analysed - remove .fits
     filename         =  'n2h+10_37'
-    # The range in velocity, x, and y over which to fit
-    ppv_vol          =  [32.0,42.0,0.0,0.0,0.0,0.0]
+    # The range in velocity, x, and y over which to fit. This is an optional
+    # keyword - not setting it will mean the whole cube will be fit - we don't
+    # want this here as we are fitting the isolated hyperfine of n2h+ (1-0)
+    ppv_vol          =  [32.0,42.0,None,None,None,None]
     # Radius for the spectral averaging areas. Pixel units.
     wsaa             =  [8.0]
-    # Tolerances for stage_3
-    tol              = [3.0, 1.0, 3.0, 2.0, 0.5]
-    # Spectral resolution
-    specres          = 0.07
+    # Tolerances for stage_3; see henshaw et al. 2016a for details. I'd keep the
+    # first and the last the same then tweak the others as necessary.
+    tol              = [3.0, 1.0, 3.0, 3.0, 0.5]
 
-    RG = True
-    nRG = 2.
-    TS = False
+    refine_grid = True
+    number_of_refinements = 2.
     verb = True
     fittype = 'gaussian'
-    njobs = 4
+    njobs = 1 # This is used for stage 3 mainly. Stages 1,2,4,5,6 will most
+              # likely be fine on a laptop but for big cubes stage 3 may need
+              # more oompf.
+    mask = 0.3 # All data below this value are masked during moment analysis.
 
-    #s = scouse.stage_1(filename, datadirectory, ppv_vol, rsaa, mask_below=0.3, verbose = verb, training_set=TS, samplesize=1, write_moments=True, save_fig=True)
+    #==========================================================================#
+    # This is stage 1 - a description can be found on the github page - used to
+    # define the coverage.
+    #==========================================================================#
     if os.path.exists(datadirectory+filename+'/stage_1/s1.scousepy'):
         s = scouse(outputdir=datadirectory, filename=filename, fittype=fittype,
                    datadirectory=datadirectory)
         s.load_stage_1(datadirectory+filename+'/stage_1/s1.scousepy')
         s.load_cube(fitsfile=filename+".fits")
     else:
-        s = scouse.stage_1(filename, datadirectory, ppv_vol, wsaa, mask_below=0.3, fittype=fittype, verbose = verb, refine_grid=RG, nrefine = nRG, write_moments=True, save_fig=True)
+        s = scouse.stage_1(filename, datadirectory, wsaa, ppv_vol=ppv_vol, mask_below=mask, fittype=fittype, verbose = verb, refine_grid=refine_grid, nrefine = number_of_refinements, write_moments=True, save_fig=True)
 
-    if os.path.exists(datadirectory+filename+'/stage_2/s2.scousepy'):
-        s.load_stage_2(datadirectory+filename+'/stage_2/s2.scousepy')
-    else:
-        s = scouse.stage_2(s, verbose=verb, write_ascii=True)
+    #==========================================================================#
+    # Stage 2 - this is the manual fitting step.
+    #==========================================================================#
+    # if os.path.exists(datadirectory+filename+'/stage_2/s2.scousepy'):
+    #     s.load_stage_2(datadirectory+filename+'/stage_2/s2.scousepy')
+    # else:
+    #     s = scouse.stage_2(s, verbose=verb, write_ascii=True)
 
-    #s = scouse.stage_2(s, verbose=verb, write_ascii=True, bitesize=True, nspec=5)
+    #==========================================================================#
+    #stage 3 - automated fitting
+    #==========================================================================#
+    # if os.path.exists(datadirectory+filename+'/stage_3/s3.scousepy'):
+    #     s.load_stage_3(datadirectory+filename+'/stage_3/s3.scousepy')
+    # else:
+    #     s = scouse.stage_3(s, tol, njobs=njobs, verbose=verb)
 
-    if os.path.exists(datadirectory+filename+'/stage_3/s3.scousepy'):
-        s.load_stage_3(datadirectory+filename+'/stage_3/s3.scousepy')
-    else:
-        s = scouse.stage_3(s, tol, njobs=njobs, verbose=verb)
+    #==========================================================================#
+    # Stage 4 - selecting the best fits
+    #==========================================================================#
+    # if os.path.exists(datadirectory+filename+'/stage_4/s4.scousepy'):
+    #     s.load_stage_4(datadirectory+filename+'/stage_4/s4.scousepy')
+    # else:
+    #     s = scouse.stage_4(s, verbose=verb)
 
-    if os.path.exists(datadirectory+filename+'/stage_4/s4.scousepy'):
-        s.load_stage_4(datadirectory+filename+'/stage_4/s4.scousepy')
-    else:
-        s = scouse.stage_4(s, verbose=verb)
+    #==========================================================================#
+    # stage 5 - checking the fits - this is interactive. It will show some
+    # helpful diagnostic plots for you to identify where the fits aren't very
+    # good. If you click the pixel you are interested in it will bring up a
+    # area of "blocksize"^2 pixels. Select ones which look bad. Pressing enter
+    # will return you to the previous plot. Pressing enter on that plot will end
+    # stage 5.
+    #==========================================================================#
+    # if os.path.exists(datadirectory+filename+'/stage_5/s5.scousepy'):
+    #     s.load_stage_5(datadirectory+filename+'/stage_5/s5.scousepy')
+    # else:
+    #     s = scouse.stage_5(s, blocksize = 6, figsize = [18,10], plot_residuals=True, verbose=verb)
 
-    if os.path.exists(datadirectory+filename+'/stage_5/s5.scousepy'):
-        s.load_stage_5(datadirectory+filename+'/stage_5/s5.scousepy')
-    else:
-        s = scouse.stage_5(s, blocksize = 6, figsize = [18,10], plot_residuals=True, verbose=verb)
-
-    #s = scouse.stage_5(s, blocksize = 6, figsize = [18,10], plot_residuals=True, verbose=verb, bitesize=True)
-
-    if os.path.exists(datadirectory+filename+'/stage_6/s6.scousepy'):
-        s.load_stage_6(datadirectory+filename+'/stage_6/s6.scousepy')
-    else:
-        s = scouse.stage_6(s, plot_neighbours=True, radius_pix = 2, figsize = [18,10], plot_residuals=True, write_ascii=True, verbose=verb)
-
-    #s = scouse.stage_6(s, plot_neighbours=True, radius_pix = 2, figsize = [18,10], plot_residuals=True, blocks_only=True, write_ascii=True, verbose=verb)
-
-    # now iterate
-    #s = scouse.stage_5(s, blocksize = 6, figsize = [18,10], plot_residuals=True, verbose=verb, repeat=True)
-    #s.load_stage_5(datadirectory+filename+'/stage_5/s5.scousepy')
-    #s = scouse.stage_6(s, plot_neighbours=True, radius_pix = 2, figsize = [18,10], plot_residuals=True, write_ascii=True, verbose=verb, repeat=True)
-
-    #s.load_stage_6(datadirectory+filename+'/stage_6/s6.scousepy')
-    #s = scouse.stage_5(s, blocksize = 6, figsize = [18,10], plot_residuals=True, verbose=verb, repeat=True)
+    #==========================================================================#
+    # Stage 6 - refitting the data you identified in stage 5
+    #==========================================================================#
+    # if os.path.exists(datadirectory+filename+'/stage_6/s6.scousepy'):
+    #     s.load_stage_6(datadirectory+filename+'/stage_6/s6.scousepy')
+    # else:
+    #     s = scouse.stage_6(s, plot_neighbours=True, radius_pix = 2, figsize = [18,10], plot_residuals=True, write_ascii=True, verbose=verb)
 
     return s
-
 
 s = run_scousepy()

--- a/scousepy/scouse.py
+++ b/scousepy/scouse.py
@@ -112,17 +112,24 @@ class scouse(object):
 
             # Read in the datacube
             if cube is None:
-                self.cube = SpectralCube.read(fitsfile).with_spectral_unit(u.km/u.s,
+                _cube = SpectralCube.read(fitsfile).with_spectral_unit(u.km/u.s,
                                                                            velocity_convention='radio')
             else:
-                self.cube = cube
+                _cube = cube
 
-            if self.cube.spectral_axis.diff()[0] < 0:
-                if np.abs(self.cube.spectral_axis[0].value - self.cube[::-1].spectral_axis[-1].value) > 1e-5:
+            if _cube.spectral_axis.diff()[0] < 0:
+                if np.abs(_cube.spectral_axis[0].value - _cube[::-1].spectral_axis[-1].value) > 1e-5:
                     raise ImportError("Update to a more recent version of spectral-cube "
                                       " or reverse the axes manually.")
-                self.cube = self.cube[::-1]
+                _cube = _cube[::-1]
 
+            # Trim cube if necessary
+            if self.ppv_vol[2]!=0 or self.ppv_vol[3]!=0:
+                _cube = _cube[:, int(self.ppv_vol[2]):int(self.ppv_vol[3]), :]
+            if self.ppv_vol[4]!=0 or self.ppv_vol[5]!=0:
+                _cube = _cube[:, :, int(self.ppv_vol[4]):int(self.ppv_vol[5])]
+
+            self.cube = _cube
             # Generate the x axis common to the fitting process
             self.x, self.xtrim, self.trimids = get_x_axis(self)
             # Compute typical noise within the spectra

--- a/scousepy/scouse.py
+++ b/scousepy/scouse.py
@@ -124,9 +124,9 @@ class scouse(object):
                 _cube = _cube[::-1]
 
             # Trim cube if necessary
-            if self.ppv_vol[2]!=0 or self.ppv_vol[3]!=0:
+            if (self.ppv_vol[2] is not None) & (self.ppv_vol[3] is not None):
                 _cube = _cube[:, int(self.ppv_vol[2]):int(self.ppv_vol[3]), :]
-            if self.ppv_vol[4]!=0 or self.ppv_vol[5]!=0:
+            if (self.ppv_vol[4] is not None) & (self.ppv_vol[5] is not None):
                 _cube = _cube[:, :, int(self.ppv_vol[4]):int(self.ppv_vol[5])]
 
             self.cube = _cube
@@ -136,8 +136,9 @@ class scouse(object):
             self.rms_approx = compute_noise(self)
 
     @staticmethod
-    def stage_1(filename, datadirectory, ppv_vol, wsaa, mask_below=0.0,
-                cube=None, verbose = False, outputdir=None,
+    def stage_1(filename, datadirectory,
+                wsaa, ppv_vol=[None, None, None, None, None, None], 
+                mask_below=0.0, cube=None, verbose = False, outputdir=None,
                 write_moments=False, save_fig=True, training_set=False,
                 samplesize=10, refine_grid=False, nrefine=3.0, autosave=True,
                 fittype='gaussian'):
@@ -151,12 +152,14 @@ class scouse(object):
             Name of the file to be loaded
         datadirectory : string
             Directory containing the datacube
-        ppv_vol : list
+        ppv_vol : list, optional
             A list containing boundaries for fitting. You can use this to
             selectively fit part of a datacube. Should be in the format
             ppv_vol = [vmin, vmax, ymin, ymax, xmin, xmax] with the velocities
             in absolute units and the x, y values in pixels. If all are set to
-            zero scouse will ignore this and just fit the whole cube.
+            None scouse will ignore this and just fit the whole cube. Default
+            is ppv_vol = [None, None, None, None, None, None]; whole cube is
+            fitted.
         wsaa : list
             The width of a spectral averaging area in pixels. Note this has
             been updated from the IDL implementation where it previously used a

--- a/scousepy/stage_1.py
+++ b/scousepy/stage_1.py
@@ -92,7 +92,7 @@ def get_x_axis(scouseobject):
     Returns x_axis for spectra
     """
     x = np.array(scouseobject.cube.world[:,0,0][0])
-    if (scouseobject.ppv_vol[0] != 0.0) & (scouseobject.ppv_vol[1] != 0.0):
+    if (scouseobject.ppv_vol[0] is not None) & (scouseobject.ppv_vol[1] is not None):
         trimids = ((x>scouseobject.ppv_vol[0])&(x<scouseobject.ppv_vol[1]))
     else:
         trimids = np.ones(np.shape(x), dtype=bool)
@@ -108,7 +108,7 @@ def get_moments(scouseobject, write_moments, dir, filename, verbose):
         progress_bar = print_to_terminal(stage='s1', step='moments')
 
     # If upper and lower limits are imposed on the velocity range
-    if (scouseobject.ppv_vol[0] != 0) & (scouseobject.ppv_vol[1] != 0):
+    if (scouseobject.ppv_vol[0] is not None) & (scouseobject.ppv_vol[1] is not None):
         momzero = scouseobject.cube.with_mask(scouseobject.cube > u.Quantity(
             scouseobject.mask_below, scouseobject.cube.unit)).spectral_slab(scouseobject.ppv_vol[0]*u.km/u.s,scouseobject.ppv_vol[1]*u.km/u.s).moment0(axis=0)
         momone = scouseobject.cube.with_mask(scouseobject.cube > u.Quantity(

--- a/scousepy/stage_1.py
+++ b/scousepy/stage_1.py
@@ -246,8 +246,9 @@ def update_coverage(cube, cx, cy, spacing, momzero, momzero_mod, cov_x, cov_y, c
 
     # Identify the locations of the non nan pixels contained within the
     # cut out
-    finite = np.isfinite(momzero_cutout)
-    nmask = np.count_nonzero(finite)
+    #finite = np.isfinite(momzero_cutout)
+    #nmask = np.count_nonzero(finite)
+    nmask = np.size(momzero_cutout)
 
     # range for looping (used below)
     rangex = range(min(limx), max(limx)+1)
@@ -273,7 +274,7 @@ def update_coverage(cube, cx, cy, spacing, momzero, momzero_mod, cov_x, cov_y, c
         if redefine:
             lim = 0.6/nrefine
         else:
-            lim = 0.5
+            lim = 0.35
 
         # If we want to keep the box...
         if fraction >= lim:

--- a/scousepy/stage_2.py
+++ b/scousepy/stage_2.py
@@ -163,7 +163,8 @@ class Stage2Fitter(object):
                          print_message=False,
                          xmin=np.min(scouseobject.xtrim),
                          xmax=np.max(scouseobject.xtrim),
-                         show_components=True)
+                         show_components=True,
+                         use_lmfit=True)
             assert self.spec.plotter._active_gui is not None
 
             self.residuals_shown = False
@@ -184,7 +185,8 @@ class Stage2Fitter(object):
                          xmin=scouseobject.ppv_vol[0],
                          xmax=scouseobject.ppv_vol[1],
                          guesses=guesses,
-                         fittype=scouseobject.fittype)
+                         fittype=scouseobject.fittype,
+                         use_lmfit=True)
             spec.specfit.plot_fit(show_components=True)
             spec.specfit.plotresiduals(axis=spec.plotter.axis,
                                        clear=False,

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ edit_on_github = True
 github_project = scousepy/scousepy
 # install_requires should be formatted as a comma-separated list, e.g.:
 # install_requires = astropy, scipy, matplotlib
-install_requires = astropy, numpy, matplotlib, pickle, spectral_cube, pyspeckit, lmfit
+install_requires = astropy, numpy, matplotlib, spectral_cube, pyspeckit, lmfit
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.0.dev0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ edit_on_github = True
 github_project = scousepy/scousepy
 # install_requires should be formatted as a comma-separated list, e.g.:
 # install_requires = astropy, scipy, matplotlib
-install_requires = astropy, numpy, matplotlib, pickle, spectral_cube, pyspeckit, lmfit-py
+install_requires = astropy, numpy, matplotlib, pickle, spectral_cube, pyspeckit, lmfit
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.0.dev0
 


### PR DESCRIPTION
Linked to issue #24 

Implemented the trimming of x and y axes in scouse.py.

Also - I realised something was a bit off with the coverage definition. In the old IDL version I would set masked values to 0.0 - spectral cube instead blanks as NaNs so the method didn't make much sense...

Previously I was establishing the number of finite values in a SAA and using this as 'nmask'. The fraction of relevant pixels was then defined as:

fraction = tot_nonzero/nmask

where tot_nonzero was the total number of finite and non-zero valued components. If this fraction was above 50% then I would include the SAA in the coverage. However, with blanking values to NaNs this doesn't quite work (more often than not the fraction is high). 

@keflavich can you check at some point this makes sense?