### PR TITLE
RMS is NaN fixes

### DIFF
--- a/scousepy/base_spectrum.py
+++ b/scousepy/base_spectrum.py
@@ -110,4 +110,7 @@ def get_rms(self, scouse, flux):
     else:
         rms = scouse.rms_approx
 
+    if np.isnan(rms):
+        raise ValueError("RMS is NaN")
+
     return rms

--- a/scousepy/scouse.py
+++ b/scousepy/scouse.py
@@ -238,7 +238,7 @@ class scouse(object):
             old_log = log.level
             log.setLevel('ERROR')
 
-            self.load_cube(fitsfile=fitsfile)
+            self.load_cube(fitsfile=fitsfile, cube=cube)
 
             # Generate moment maps
             momzero, momone, momtwo, momnine = get_moments(self, write_moments,

--- a/scousepy/stage_1.py
+++ b/scousepy/stage_1.py
@@ -83,6 +83,16 @@ def calc_rms(spectrum):
 
     # Find all negative values
     negative_indices = (spectrum < 0.0)
+
+    if negative_indices.sum() < 2:
+        # spectrum is not continuum subtracted, maybe?
+        # first baseline-subtract the spectrum conservatively
+        # (note that this is a reassignment operation, it doesn't change the
+        # data)
+        spectrum = spectrum - np.percentile(spectrum, 25)
+        negative_indices = (spectrum < 0.0)
+        assert negative_indices.sum() >= 2
+
     spectrum_negative_values = spectrum[negative_indices]
     reflected_noise = np.concatenate((spectrum[negative_indices],
                                                abs(spectrum[negative_indices])))
@@ -96,6 +106,9 @@ def calc_rms(spectrum):
         maximum_value = 4.0*MAD
     noise = spectrum[spectrum < abs(maximum_value)]
     rms = np.sqrt(np.sum(noise**2) / np.size(noise))
+
+    if np.isnan(rms):
+        raise ValueError("RMS was NaN, which is not allowed.")
 
     return rms
 

--- a/scousepy/stage_3.py
+++ b/scousepy/stage_3.py
@@ -381,7 +381,7 @@ def fitting_process_parent(scouseobject, SAA, key, spec, parent_model):
                         warnings.simplefilter('ignore')
                         old_log = log.level
                         log.setLevel('ERROR')
-                        if np.any(np.isnan(sp.error)):
+                        if np.any(np.isnan(spec.error)):
                             raise ValueError("NaNs in sp.error")
                         spec.specfit(interactive=False, \
                                     clear_all_connections=True,\


### PR DESCRIPTION
added a boatload of checks for rms being NaN to try to catch it earlier. Most
of these are unnecessary, but they might be harmless to have around too?

Also added a correction where if the data are all positive, the "reflected RMS" doesn't work.