### PR TITLE
Rms nan handling

### DIFF
--- a/scousepy/base_spectrum.py
+++ b/scousepy/base_spectrum.py
@@ -107,6 +107,8 @@ def get_rms(self, scouse, flux):
     spectrum = flux
     if not np.isnan(spectrum).any() and not (spectrum > 0).all():
         rms = calc_rms(spectrum)
+        if np.isnan(rms):
+            rms=scouse.rms_approx
     else:
         rms = scouse.rms_approx
 

--- a/scousepy/stage_1.py
+++ b/scousepy/stage_1.py
@@ -66,11 +66,10 @@ def compute_noise(scouseobject):
         stopcount+=1
         specidx+=1
 
-    rms = np.nanmedian(rmsList)
-
-    if np.isnan(rms):
-        raise ValueError("RMS was NaN, which is not allowed.")
+    if np.all(~np.isfinite(np.asarray(rmsList))):
+        raise ValueError("All RMS are NaN, which is not allowed.")
     else:
+        rms = np.nanmedian(rmsList)
         return rms
 
 def calc_rms(spectrum):


### PR DESCRIPTION
working on the assumption that this should be caught during stage 1. 

scouse computes the rms value across all pixels to start with. If all values are nan then raise an error. if some are nan then return the cube rms as using nanmedian. 

during stage 3, if the returned rms value is nan or if there are any nans in the spectrum then return the rms_approx value (nanmedian of all rms values)